### PR TITLE
WIP: Fix path in client setup.sh

### DIFF
--- a/shared-build-context/client/scripts/setup.sh
+++ b/shared-build-context/client/scripts/setup.sh
@@ -5,7 +5,7 @@
 set -uxe
 
 # distcc provides gcc/g++ wrappers, but not cc, so create additional symlink
-if [ -d /usr/bin/distcc/bin ]; then
+if [ -d /usr/lib/distcc/bin ]; then
   # archlinux/alpine
   ln -s /usr/bin/distcc /usr/lib/distcc/bin/cc || true
 else


### PR DESCRIPTION
This does not make the tests pass yet, but definitely `/usr/bin/distcc/bin` isn't a thing, so one step ahead.